### PR TITLE
Template SHARP Validation

### DIFF
--- a/padre_sharp/__init__.py
+++ b/padre_sharp/__init__.py
@@ -1,4 +1,6 @@
 # see license/LICENSE.rst
+from pathlib import Path
+
 try:
     from ._version import version as __version__
     from ._version import version_tuple
@@ -21,3 +23,7 @@ log.debug(f"padre_sharp version: {__version__}")
 
 MISSION_NAME = "PADRE"
 INSTRUMENT_NAME = "SHARP"
+
+_package_directory = Path(__file__).parent
+_data_directory = _package_directory / "data"
+_test_files_directory = _package_directory / "data" / "test"

--- a/padre_sharp/calibration/calibration.py
+++ b/padre_sharp/calibration/calibration.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 
 from swxsoc.util import util
 from padre_sharp import log
+from padre_sharp.util import validation
 
 __all__ = [
     "process_file",
@@ -35,6 +36,16 @@ def process_file(data_filename: Path) -> list:
     """
     log.info(f"Processing file {data_filename}.")
     output_files = []
+    data_filename = Path(data_filename)
+
+    if data_filename.suffix == ".bin":
+        # Before we process, validate the file with CCSDS
+        custom_validators = [validation.validate_packet_checksums]
+        validation_findings = validation.validate(
+            data_filename, custom_validators=custom_validators
+        )
+        for finding in validation_findings:
+            log.warning(f"Validation Finding for File : {data_filename} : {finding}")
 
     calibrated_file = calibrate_file(data_filename)
     output_files.append(calibrated_file)

--- a/padre_sharp/tests/test_util_validation.py
+++ b/padre_sharp/tests/test_util_validation.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+import padre_sharp
+from padre_sharp.util import validation
+
+
+def test_validate_packet_checksums():
+    # TODO Insert you own test file here - Remove the FileNotFoundError when you have a test file
+    with pytest.raises(FileNotFoundError):
+        test_file = padre_sharp._test_files_directory / "apid160_4packets.bin"
+        warnings = validation.validate_packet_checksums(test_file)
+        # assert len(warnings) == 0
+
+
+def test_validate():
+    # TODO Insert you own test file here - Remove the FileNotFoundError when you have a test file
+    test_file = padre_sharp._test_files_directory / "apid160_4packets.bin"
+    warnings = validation.validate(test_file)
+    assert len(warnings) == 1
+    assert "No such file or directory:" in warnings[0]

--- a/padre_sharp/util/validation.py
+++ b/padre_sharp/util/validation.py
@@ -1,0 +1,84 @@
+"""
+This module contains utilities for file and packet validation.
+"""
+
+from typing import List
+
+import numpy as np
+from ccsdspy import utils
+
+
+def validate_packet_checksums(file) -> List[str]:
+    """
+    Custom Validation Function to check that all packets have contents that match their checksums. This is achieved be a rolling XOR of the packet contents. If the final XOR value is not 0, a warning is issued.
+
+    Parameters
+    ----------
+    file: `str | BytesIO`
+        A file path (str) or file-like object with a `.read()` method.
+
+    Returns
+    -------
+    List of strings, each in the format "WarningType: message", describing potential validation issues. Returns an empty list if no warnings are issued.
+    """
+    validation_warnings = []
+    # Read the file
+    packets = utils.split_packet_bytes(file)
+    for i, packet in enumerate(packets):
+        # Convert to an array of u16 integers
+        packet_arr = np.frombuffer(packet, dtype=np.uint8)
+
+        # Insert your custom checksum validation here
+        # Included is MEDDEA's checksum validation as an example
+
+        # checksum_validation = np.bitwise_xor.reduce(packet_arr)
+        checksum_validation = 0
+
+        # Make sure the Checksum Validation was correct
+        # For MEDDEA This means the checksum_validation should be 0
+        # Modify for you own checksum validation
+        if checksum_validation != 0:
+            validation_warnings.append(
+                f"ChecksumWarning: Packet {i} has a checksum error."
+            )
+
+    return validation_warnings
+
+
+def validate(
+    file, valid_apids: List[int] = None, custom_validators: List[callable] = None
+) -> List[str]:
+    """
+    Validate a file containing CCSDS packets and capturing any exceptions or warnings they generate.
+    This function checks:
+
+    - Primary header consistency (sequence counts in order, no missing sequence numbers, found APIDs)
+    - File integrity (truncation, extra bytes)
+
+    Parameters
+    ----------
+    file: `str | BytesIO`
+        A file path (str) or file-like object with a `.read()` method.
+    valid_apids: `list[int]| None`, optional
+       Optional list of valid APIDs. If specified, warning will be issued when
+       an APID is encountered outside this list.
+    custom_validators: `List[callable]`, optional
+        List of custom validation functions that take a file-like object as input and return a list of warnings
+
+    Returns
+    -------
+    List of strings, each in the format "WarningType: message", describing
+    potential validation issues. Returns an empty list if no warnings are issued.
+    """
+    validation_warnings = []
+    # Run Baseline CCSDSPy validation
+    ccsdspy_warnings = utils.validate(file, valid_apids)
+    validation_warnings.extend(ccsdspy_warnings)
+    # Run custom validation functions
+    if custom_validators:
+        for validator in custom_validators:
+            # Execute Custom Validator
+            custom_warnings = validator(file)
+            validation_warnings.extend(custom_warnings)
+
+    return validation_warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 dependencies = [
   'astropy',
   'sunpy',
+  'numpy==2.2.*',
+  'ccsdspy==1.4.*',
   'swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main',
 ]
 


### PR DESCRIPTION
This is a template for CCSDS Space Packet Validation in the Pipeline. This should mirror changes made in MEDDEA Processing here: https://github.com/PADRESat/padre_meddea/pull/34

* This adds a `padre_sharp.util.validation.validate()` function that executes validation from CCSDSPy package functions. 
* Additionally adds stub code for `padre_sharp.util.validation.validate_packet_checksums()` to check individual packet checksums based on custom checksum approach. 
* Adds calls in the main `padre_sharp.calibration.calibration.process_file()` function to execute the validation and log any validation findings. These logs can be parsed by our AWS Grafana dashboard. 